### PR TITLE
Add title screen with SUPER RED branding

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,11 @@
 import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <>
+      <StatusBar style="light" />
+      <Stack screenOptions={{ headerShown: false }} />
+    </>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,25 @@
-import { Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
+import { Colors } from "@/constants/colors";
 
 export default function Index() {
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
+    <View style={styles.container}>
+      <Text style={styles.title}>SUPER RED</Text>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.background,
+  },
+  title: {
+    fontSize: 48,
+    fontWeight: "900",
+    letterSpacing: 4,
+    color: Colors.title,
+  },
+});

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -1,0 +1,5 @@
+export const Colors = {
+  background: "#1A1A2E", // deep dark blue-black
+  title: "#E63946", // vibrant red
+  text: "#F1FAEE", // off-white
+} as const;


### PR DESCRIPTION
## Summary
- Create `constants/colors.ts` with game-wide color palette (dark background, vibrant red, off-white)
- Update root layout to hide navigation header and set light status bar for dark theme
- Replace placeholder screen with centered "SUPER RED" title (fontSize 48, fontWeight 900, letterSpacing 4)

## Test plan
- [x] Verify title screen renders with "SUPER RED" centered on dark background
- [x] Verify status bar icons are white (light style)
- [x] Verify no navigation header is shown

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)