### PR TITLE
Display character and ground on game screen

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,10 +1,19 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
+import { Character } from "@/components/game/character";
+import { Ground } from "@/components/game/ground";
 import { Colors } from "@/constants/colors";
+import { CHARACTER_LEFT, GROUND_HEIGHT } from "@/constants/game";
 
 export default function Game() {
+  const characterY = useSharedValue(0);
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Game Screen</Text>
+      <View style={styles.character}>
+        <Character y={characterY} />
+      </View>
+      <Ground />
     </View>
   );
 }
@@ -12,12 +21,11 @@ export default function Game() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
     backgroundColor: Colors.background,
   },
-  text: {
-    fontSize: 24,
-    color: Colors.text,
+  character: {
+    position: "absolute",
+    left: CHARACTER_LEFT,
+    bottom: GROUND_HEIGHT,
   },
 });

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/components/game/character.tsx
+++ b/components/game/character.tsx
@@ -1,0 +1,25 @@
+import type { SharedValue } from "react-native-reanimated";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { Colors } from "@/constants/colors";
+import { CHARACTER_SIZE } from "@/constants/game";
+
+type CharacterProps = {
+  y: SharedValue<number>;
+};
+
+export function Character({ y }: CharacterProps) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: y.value }],
+  }));
+
+  return <Animated.View style={[styles.character, animatedStyle]} />;
+}
+
+const styles = {
+  character: {
+    width: CHARACTER_SIZE,
+    height: CHARACTER_SIZE,
+    backgroundColor: Colors.character,
+    borderRadius: 4,
+  },
+} as const;

--- a/components/game/ground.tsx
+++ b/components/game/ground.tsx
@@ -1,0 +1,18 @@
+import { StyleSheet, View } from "react-native";
+import { Colors } from "@/constants/colors";
+import { GROUND_HEIGHT } from "@/constants/game";
+
+export function Ground() {
+  return <View style={styles.ground} />;
+}
+
+const styles = StyleSheet.create({
+  ground: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: GROUND_HEIGHT,
+    backgroundColor: Colors.ground,
+  },
+});

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -2,4 +2,6 @@ export const Colors = {
   background: "#1A1A2E", // deep dark blue-black
   title: "#E63946", // vibrant red
   text: "#F1FAEE", // off-white
+  character: "#E63946", // vibrant red (matches title)
+  ground: "#2D2D4A", // subtle dark purple
 } as const;

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -1,0 +1,3 @@
+export const CHARACTER_SIZE = 50;
+export const GROUND_HEIGHT = 60;
+export const CHARACTER_LEFT = 50;


### PR DESCRIPTION
## Summary

- Add Character component (red square) using Reanimated `Animated.View` with shared Y value for future jump support
- Add Ground component (dark purple strip at screen bottom)
- Add game layout constants (`CHARACTER_SIZE`, `GROUND_HEIGHT`, `CHARACTER_LEFT`) and colors
- Replace placeholder game screen with character + ground layout
- Enable Biome VCS integration to respect `.gitignore`

Closes #19

## Test plan

- [x] Run `pnpm expo start --ios` and navigate to game screen — verify red square appears on the left above the ground strip
- [x] Verify ground strip spans full width at the bottom
- [x] Run `pnpm expo lint`, `pnpm format:check`, `pnpm tsc --noEmit` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)