### PR TITLE
Add AABB collision detection between character and bombs

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -11,6 +11,7 @@ import {
   BOMB_MIN_GAP,
   BOMB_SIZE,
   CHARACTER_LEFT,
+  CHARACTER_SIZE,
   GRAVITY,
   GROUND_HEIGHT,
   JUMP_VELOCITY,
@@ -23,6 +24,7 @@ export default function Game() {
   const characterY = useSharedValue(0);
   const velocityY = useSharedValue(0);
   const isJumping = useSharedValue(false);
+  const isGameOver = useSharedValue(false);
   const scrollX = useSharedValue(0);
   const bombPositions = useSharedValue(
     Array.from(
@@ -32,6 +34,8 @@ export default function Game() {
   );
 
   useFrameCallback(() => {
+    if (isGameOver.value) return;
+
     scrollX.value -= SCROLL_SPEED;
 
     // Move bombs
@@ -47,6 +51,19 @@ export default function Game() {
     }
     bombPositions.value = positions;
 
+    // Collision detection (AABB)
+    for (let i = 0; i < positions.length; i++) {
+      const bombX = positions[i];
+      const horizontalOverlap =
+        CHARACTER_LEFT < bombX + BOMB_SIZE &&
+        CHARACTER_LEFT + CHARACTER_SIZE > bombX;
+      const verticalOverlap = characterY.value > -BOMB_SIZE;
+      if (horizontalOverlap && verticalOverlap) {
+        isGameOver.value = true;
+        return;
+      }
+    }
+
     if (!isJumping.value) return;
 
     velocityY.value += GRAVITY;
@@ -60,6 +77,7 @@ export default function Game() {
   });
 
   const handleJump = () => {
+    if (isGameOver.value) return;
     if (isJumping.value) return;
     velocityY.value = JUMP_VELOCITY;
     isJumping.value = true;


### PR DESCRIPTION
## Summary
- Add per-frame AABB collision detection between the character and bombs
- Set `isGameOver` shared value flag on first collision, freezing all game updates
- Guard jump handler to prevent jumping after game over

## Test plan
- [x] Run the game and confirm normal scrolling/jumping works
- [x] Let a bomb hit the character and verify the game freezes (no scrolling, no bomb movement, no physics)
- [x] Verify tapping after game over does not trigger a jump
- [x] Jump over a bomb and confirm no collision is detected when clearing it

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)