### PR TITLE
Add game over screen

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet, Text, View } from "react-native";
+import { Colors } from "@/constants/colors";
+
+export default function GameOver() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>GAME OVER</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 48,
+    fontWeight: "900",
+    letterSpacing: 4,
+    color: Colors.title,
+  },
+});

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,5 +1,11 @@
+import { router } from "expo-router";
 import { Dimensions, Pressable, StyleSheet, View } from "react-native";
-import { useFrameCallback, useSharedValue } from "react-native-reanimated";
+import {
+  runOnJS,
+  useAnimatedReaction,
+  useFrameCallback,
+  useSharedValue,
+} from "react-native-reanimated";
 import { BackgroundObjects } from "@/components/game/background-objects";
 import { Bombs } from "@/components/game/bombs";
 import { Character } from "@/components/game/character";
@@ -31,6 +37,19 @@ export default function Game() {
       { length: BOMB_COUNT },
       (_, i) => SCREEN_WIDTH + BOMB_MIN_GAP * (i + 1),
     ),
+  );
+
+  const navigateToGameOver = () => {
+    router.replace("/game-over");
+  };
+
+  useAnimatedReaction(
+    () => isGameOver.value,
+    (current, previous) => {
+      if (current && !previous) {
+        runOnJS(navigateToGameOver)();
+      }
+    },
   );
 
   useFrameCallback(() => {


### PR DESCRIPTION
## Summary
- Add `/game-over` route with centered "GAME OVER" text on dark background
- Navigate from game screen to game-over screen when `isGameOver` becomes `true` using `useAnimatedReaction` + `runOnJS`
- Use `router.replace` to prevent navigating back to frozen game screen

Closes #28

## Test plan
- [x] Start the game and collide with a bomb
- [x] Verify "GAME OVER" screen is displayed with correct styling
- [x] Verify pressing back does not return to the game screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)