### PR TITLE
Add retry button to game over screen

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -1,10 +1,17 @@
-import { StyleSheet, Text, View } from "react-native";
+import { router } from "expo-router";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Colors } from "@/constants/colors";
 
 export default function GameOver() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>GAME OVER</Text>
+      <Pressable
+        style={styles.retryButton}
+        onPress={() => router.replace("/game")}
+      >
+        <Text style={styles.retryText}>RETRY</Text>
+      </Pressable>
     </View>
   );
 }
@@ -21,5 +28,13 @@ const styles = StyleSheet.create({
     fontWeight: "900",
     letterSpacing: 4,
     color: Colors.title,
+  },
+  retryButton: {
+    marginTop: 32,
+  },
+  retryText: {
+    fontSize: 18,
+    letterSpacing: 3,
+    color: Colors.text,
   },
 });


### PR DESCRIPTION
## Summary
- Add a RETRY button to the game over screen that restarts the game
- Uses router.replace to navigate back to the game screen
- Styled consistently with the home screen TAP TO START text

Closes #29

## Test plan
- [x] Start the game and collide with a bomb to trigger game over
- [x] Verify RETRY text appears below GAME OVER
- [x] Tap the retry button and verify a new game starts