### PR TITLE
Add collision visual effects

### DIFF
--- a/constants/game.ts
+++ b/constants/game.ts
@@ -14,3 +14,8 @@ export const BOMB_SIZE = 40;
 export const BOMB_COUNT = 3;
 export const BOMB_MIN_GAP = 300;
 export const BOMB_MAX_GAP = 600;
+
+export const GAME_OVER_EFFECT_FRAMES = 30;
+export const SHAKE_FRAMES = 20;
+export const SHAKE_INTENSITY = 10;
+export const FLASH_PEAK_OPACITY = 0.6;


### PR DESCRIPTION
## Summary
- Add screen shake (20 frames) and red flash overlay on bomb collision
- Delay game over transition by ~500ms (30 frames) to play effects before navigating
- Replace instant `useAnimatedReaction` navigation with frame-counted effect sequence in `useFrameCallback`

## Test plan
- [x] Collide with a bomb and verify screen shakes briefly
- [x] Verify red flash overlay appears and fades out
- [x] Verify game over screen appears after ~500ms delay
- [x] Verify normal gameplay (jumping, scrolling) is unaffected

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)