### PR TITLE
Update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,82 @@
-# Welcome to your Expo app 👋
+# Super Red
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+An endless-runner style mobile game built with Expo and React Native. Jump to dodge bombs and survive as long as you can.
 
-## Get started
+## Tech Stack
 
-1. Install dependencies
+- **Expo SDK 54** / React Native 0.83 / React 19
+- **TypeScript** (strict mode)
+- **Expo Router** (file-based routing with typed routes)
+- **React Native Reanimated** (frame-based game loop and animations)
+- React Native New Architecture and React Compiler enabled
 
-   ```bash
-   npm install
-   ```
+## Game Features
 
-2. Start the app
+- Tap-to-start title screen
+- One-button jump gameplay with gravity physics
+- Scrolling ground and parallax background
+- Randomly spaced bomb obstacles
+- AABB collision detection
+- Game over effects (screen shake and flash)
+- Survival time display and retry
 
-   ```bash
-   npx expo start
-   ```
+## Getting Started
 
-In the output, you'll find options to open the app in a
+### Prerequisites
 
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
+- [Node.js](https://nodejs.org/) (v22 recommended)
+- [pnpm](https://pnpm.io/)
 
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-## Get a fresh project
-
-When you're ready, run:
+### Install and Run
 
 ```bash
-npm run reset-project
+# Install dependencies
+pnpm install
+
+# Start the development server
+pnpm expo start
 ```
 
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+Then open the app on your preferred platform:
 
-## Learn more
+```bash
+pnpm expo start --ios
+pnpm expo start --android
+pnpm expo start --web
+```
 
-To learn more about developing your project with Expo, look at the following resources:
+## Development
 
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
+### Commands
 
-## Join the community
+```bash
+pnpm expo lint     # ESLint
+pnpm format        # Biome formatter (write)
+pnpm format:check  # Biome formatter (check)
+```
 
-Join our community of developers creating universal apps.
+### Project Structure
 
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+```txt
+app/
+  _layout.tsx       # Root Stack navigator
+  index.tsx         # Title screen ("Tap to Start")
+  game.tsx          # Main gameplay (game loop, physics, collision)
+  game-over.tsx     # Game over screen (time display, retry)
+components/game/
+  character.tsx     # Player character with jump animation
+  bombs.tsx         # Scrolling bomb obstacles
+  ground.tsx        # Scrolling ground
+  background-objects.tsx  # Parallax background decorations
+constants/
+  game.ts           # Game physics and dimensions
+  colors.ts         # Color palette
+```
+
+### CI
+
+Runs on every PR via GitHub Actions:
+
+1. ESLint
+2. Biome format check
+3. TypeScript type check


### PR DESCRIPTION
## Summary
- Replace the default Expo template README with project-specific content
- Add tech stack, game features, setup instructions, project structure, and CI information
- Fix package manager references from npm/npx to pnpm

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)