### PR TITLE
Add plan-refactor skill

### DIFF
--- a/.claude/skills/plan-refactor/SKILL.md
+++ b/.claude/skills/plan-refactor/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-refactor
 description: Analyze the codebase for refactoring opportunities, create a plan, and file GitHub issues for each proposal.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash(gh *), Bash(wc *), Bash(pnpm tsc --noEmit), Bash(pnpm expo lint), Bash(pnpm format:check)
+allowed-tools: Read, Grep, Glob, Bash(gh *), WebFetch
 ---
 
 # Plan Refactor
@@ -11,53 +11,29 @@ Analyze the codebase for refactoring opportunities, present a plan to the user, 
 
 ## Steps
 
-### 1. Analyze the codebase
+1. **Analyze the codebase** — Explore the codebase to identify refactoring opportunities. Focus on:
+   - **Large files** — Files that mix multiple concerns and could benefit from extraction (hooks, utilities, constants)
+   - **Duplication** — Repeated styles, logic, or patterns across files
+   - **Inconsistency** — Style definitions, naming conventions, or patterns that differ from the rest of the codebase
+   - **Magic numbers** — Hardcoded values that should be named constants
+   - **Dead code** — Unused imports, variables, or exports
 
-Explore the codebase to identify refactoring opportunities. Focus on:
+   Use the project's CLAUDE.md to understand conventions and architecture.
 
-- **Large files** — Files that mix multiple concerns and could benefit from extraction (hooks, utilities, constants)
-- **Duplication** — Repeated styles, logic, or patterns across files
-- **Inconsistency** — Style definitions, naming conventions, or patterns that differ from the rest of the codebase
-- **Magic numbers** — Hardcoded values that should be named constants
-- **Dead code** — Unused imports, variables, or exports
+2. **Clarify unknowns** — If the analysis reveals ambiguous areas or multiple valid approaches, ask the user before proceeding. Do not make assumptions on ambiguous points.
 
-Use the project's CLAUDE.md to understand conventions and architecture.
+3. **Draft the plan** — Write a refactoring plan listing each proposal. Use the template in [plan-template.md](plan-template.md) for each proposal. Keep proposals independent — each should be implementable on its own.
 
-### 2. Draft the refactoring plan
+4. **Present to the user** — Show the full plan and ask for approval. The user may:
+   - Approve all proposals
+   - Remove or modify specific proposals
+   - Ask for additional analysis
 
-Write a refactoring plan using the template in [refactor-template.md](refactor-template.md). For each proposal:
+   Do NOT proceed to issue creation until the user explicitly approves.
 
-- Be specific about which files and lines are affected
-- Describe what changes concretely (not just "refactor this")
-- Include code snippets when they clarify the target structure
-- Explain the benefit (separation of concerns, reduced duplication, consistency, etc.)
-- Keep proposals independent — each should be implementable on its own
+5. **Create GitHub issues** — For each approved proposal, create a separate GitHub issue using `gh issue create --title "<title>" --body "<plan>"`. Use a HEREDOC for the body to preserve formatting. Title is Short, imperative, in English (e.g., "Extract game loop logic into a custom hook").
 
-### 3. Present to the user
-
-Show the full plan to the user and ask for approval. The user may:
-- Approve all proposals
-- Remove or modify specific proposals
-- Ask for additional analysis
-
-Do NOT proceed to issue creation until the user explicitly approves.
-
-### 4. Create GitHub issues
-
-For each approved proposal, create a separate GitHub issue using `gh issue create`. Each issue should contain:
-
-- **Title** — Short, imperative, in English (e.g., "Extract game loop logic into a custom hook")
-- **Body** — Structured with:
-  - `## Context` — Current state and why the change is needed
-  - `## Proposed Changes` — Concrete list of changes, with code snippets if helpful
-  - `## Expected Outcome` — Benefits of the change
-  - `## Files to Change` — Table of affected files and what changes
-
-Use a HEREDOC for the issue body to preserve formatting.
-
-### 5. Report results
-
-After all issues are created, show the user a summary table with issue numbers, titles, and URLs.
+6. **Report results** — After all issues are created, show the user a summary table with issue numbers, titles, and URLs.
 
 ## Guidelines
 
@@ -65,5 +41,7 @@ After all issues are created, show the user a summary table with issue numbers, 
 - Converse with the user in Japanese (project convention).
 - Keep proposals minimal and focused — one concern per issue.
 - Do not propose changes that add complexity without clear benefit.
-- Reference actual file paths and line numbers discovered during exploration.
-- Proposals should be independent so they can be implemented in any order.
+- Reference actual file paths discovered during exploration, not guessed paths.
+- For each file change, specify whether it is Create, Modify, or Delete.
+- Do not include full code in the plan — describe what changes are needed and why.
+- Code snippets are acceptable when they clarify intent (e.g., type definitions, key structures).

--- a/.claude/skills/plan-refactor/plan-template.md
+++ b/.claude/skills/plan-refactor/plan-template.md
@@ -1,5 +1,3 @@
-<!-- This template defines the structure for each GitHub issue created by plan-refactor. -->
-
 ## Context
 
 <!-- What is the current state and why does it need to change? Reference specific files and line numbers. -->
@@ -12,8 +10,9 @@
 
 <!-- Benefits of the change (separation of concerns, reduced duplication, consistency, etc.) -->
 
-## Files to Change
+## Files
 
-| File | Change |
-|------|--------|
-| `path/to/file.ts` | Description of change |
+| Action | Path |
+|--------|------|
+| Create | `path/to/file.ts` |
+| Modify | `path/to/file.ts` |


### PR DESCRIPTION
## Summary
- Add `/plan-refactor` skill that analyzes the codebase for refactoring opportunities, presents a plan, and creates individual GitHub issues for each proposal
- Includes `refactor-template.md` defining the issue body structure (Context, Proposed Changes, Expected Outcome, Files to Change)

## Test plan
- [x] Run `/plan-refactor` and verify it analyzes the codebase
- [x] Verify the generated plan follows the template structure
- [x] Verify GitHub issues are created with correct formatting after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)