### PR TITLE
Translate support page to English and align styling with privacy page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width'>
+  <title>SUPER RED - Support</title>
+  <style>
+    body {
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      padding: 1em;
+    }
+  </style>
+</head>
+
+<body>
+  <strong>SUPER RED Support</strong>
+  <p>Thank you for using SUPER RED.</p>
+
+  <br><strong>Contact</strong>
+  <p>For bug reports, feedback, or feature requests, please contact us at letters_roux.4k@icloud.com.</p>
+
+  <br><strong>Privacy Policy</strong>
+  <p>Please refer to our <a href="./privacy.html">Privacy Policy</a> for details on how we handle your data.</p>
+
+  <hr>
+  <p><small>&copy; 2026 Takeyuki Adachi</small></p>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- Translated `docs/index.html` from Japanese to English
- Aligned HTML structure and CSS styling with `docs/privacy.html` (same font, viewport meta, heading style)
- Replaced placeholder text (`[アプリ名]`, `[あなたの名前/チーム名]`) with actual values

## Test plan
- [x] Open `docs/index.html` in a browser and verify content is in English
- [ ] Compare visual appearance with `docs/privacy.html` to confirm consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)