### PR TITLE
Raise ground height from 60px to 120px

### DIFF
--- a/constants/game.ts
+++ b/constants/game.ts
@@ -1,6 +1,6 @@
 export const CHARACTER_SIZE = 50;
 export const CHARACTER_HEIGHT = 73;
-export const GROUND_HEIGHT = 60;
+export const GROUND_HEIGHT = 120;
 export const CHARACTER_LEFT = 50;
 
 export const JUMP_VELOCITY = -30;


### PR DESCRIPTION
## Summary
- Increase GROUND_HEIGHT from 60 to 120 in constants/game.ts to improve the game visual layout
- All game components (character, bombs, items, background objects, ground renderer) reference this single constant, so the change propagates automatically

Closes #68

## Test plan
- [x] Verify the ground strip renders at the new 120px height
- [x] Confirm the character stands on the raised ground
- [x] Check that bombs, items, and background objects position correctly relative to the new ground

Generated with [Claude Code](https://claude.com/claude-code)