### PR TITLE
Add TITLE button to game-over screen

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -32,6 +32,9 @@ export default function GameOver() {
       >
         <Text style={styles.retryText}>RETRY</Text>
       </Pressable>
+      <Pressable style={styles.retryButton} onPress={() => router.replace("/")}>
+        <Text style={styles.retryText}>TITLE</Text>
+      </Pressable>
     </View>
   );
 }


### PR DESCRIPTION
## Summary

- Add a TITLE button below the existing RETRY button on the game-over screen
- Uses router.replace("/") to navigate back to the title screen, consistent with the app navigation pattern
- Reuses existing retryButton / retryText styles for visual consistency

Closes #72

## Test plan

- [x] Open the game-over screen after finishing a game
- [x] Verify the TITLE button appears below the RETRY button
- [x] Tap TITLE and confirm it navigates to the title screen
- [x] Verify RETRY still works as expected

Generated with [Claude Code](https://claude.com/claude-code)