### PR TITLE
Improve tap target size and visual affordance for game-over buttons

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -26,14 +26,11 @@ export default function GameOver() {
           <Text style={styles.bestValue}>{highScore} pts</Text>
         </>
       )}
-      <Pressable
-        style={styles.retryButton}
-        onPress={() => router.replace("/game")}
-      >
-        <Text style={styles.retryText}>RETRY</Text>
+      <Pressable style={styles.button} onPress={() => router.replace("/game")}>
+        <Text style={styles.buttonText}>RETRY</Text>
       </Pressable>
-      <Pressable style={styles.retryButton} onPress={() => router.replace("/")}>
-        <Text style={styles.retryText}>TITLE</Text>
+      <Pressable style={styles.button} onPress={() => router.replace("/")}>
+        <Text style={styles.buttonText}>TITLE</Text>
       </Pressable>
     </View>
   );
@@ -81,10 +78,15 @@ const styles = StyleSheet.create({
     marginTop: 8,
     color: Colors.text,
   },
-  retryButton: {
+  button: {
     marginTop: 32,
+    paddingVertical: 14,
+    paddingHorizontal: 40,
+    borderWidth: 2,
+    borderColor: Colors.text,
+    borderRadius: 8,
   },
-  retryText: {
+  buttonText: {
     ...Typography.body,
     color: Colors.text,
   },


### PR DESCRIPTION
## Summary
- Add `paddingVertical: 14`, `paddingHorizontal: 40`, `borderWidth: 2`, `borderColor`, and `borderRadius: 8` to game-over buttons so they meet minimum touch target guidelines and look tappable
- Rename `retryButton`/`retryText` styles to `button`/`buttonText` since both RETRY and TITLE buttons share them

Closes #70

## Test plan
- [x] Open the game-over screen and verify RETRY and TITLE buttons have visible border outlines
- [x] Tap both buttons and confirm they are easy to hit and navigate correctly
- [x] Verify button spacing and visual appearance on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)