### PR TITLE
Raise GROUND_HEIGHT from 120 to 350

### DIFF
--- a/constants/game.ts
+++ b/constants/game.ts
@@ -1,6 +1,6 @@
 export const CHARACTER_SIZE = 50;
 export const CHARACTER_HEIGHT = 73;
-export const GROUND_HEIGHT = 120;
+export const GROUND_HEIGHT = 350;
 export const CHARACTER_LEFT = 50;
 
 export const JUMP_VELOCITY = -30;


### PR DESCRIPTION
## Summary
- Increase `GROUND_HEIGHT` from 120 to 350 in `constants/game.ts` to improve the visual layout

Closes #68

## Test plan
- [ ] Verify the ground position is visually raised on iOS/Android
- [ ] Confirm character, bombs, items, and background objects are positioned correctly relative to the new ground height

🤖 Generated with [Claude Code](https://claude.com/claude-code)