### PR TITLE
Enhance score visibility with text shadow and larger font

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -61,6 +61,9 @@ const styles = StyleSheet.create({
   scoreValue: {
     ...Typography.score,
     color: Colors.text,
+    textShadowColor: "rgba(0, 0, 0, 0.5)",
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 4,
   },
   newBadge: {
     ...Typography.label,
@@ -77,6 +80,9 @@ const styles = StyleSheet.create({
     ...Typography.score,
     marginTop: 8,
     color: Colors.text,
+    textShadowColor: "rgba(0, 0, 0, 0.5)",
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 4,
   },
   button: {
     marginTop: 32,

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -98,6 +98,9 @@ const styles = StyleSheet.create({
     right: 20,
     ...Typography.score,
     color: Colors.text,
+    textShadowColor: "rgba(0, 0, 0, 0.5)",
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 4,
   },
   flashOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/constants/typography.ts
+++ b/constants/typography.ts
@@ -2,6 +2,6 @@
 export const Typography = {
   title: { fontSize: 48, fontWeight: "900", letterSpacing: 4 },
   label: { fontSize: 20, fontWeight: "700", letterSpacing: 3 },
-  score: { fontSize: 28, fontWeight: "700", letterSpacing: 2 },
+  score: { fontSize: 36, fontWeight: "700", letterSpacing: 2 },
   body: { fontSize: 18, letterSpacing: 3 },
 } as const;


### PR DESCRIPTION
## Summary
- Increase `Typography.score` font size from 28 to 36 for better readability during gameplay
- Add dark semi-transparent text shadow (`rgba(0, 0, 0, 0.5)`) to score HUD in `game.tsx`
- Apply the same text shadow to `scoreValue` and `bestValue` in `game-over.tsx` for consistency

Closes #81

## Test plan
- [x] Verify in-game score HUD is more readable against the teal background
- [x] Verify game-over screen score and best score values have visible text shadows
- [x] Confirm font size increase does not cause layout overflow on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)