### PR TITLE
Improve score display with badge UI and remove text shadows

### DIFF
--- a/app/game-over.tsx
+++ b/app/game-over.tsx
@@ -61,9 +61,6 @@ const styles = StyleSheet.create({
   scoreValue: {
     ...Typography.score,
     color: Colors.text,
-    textShadowColor: "rgba(0, 0, 0, 0.5)",
-    textShadowOffset: { width: 1, height: 1 },
-    textShadowRadius: 4,
   },
   newBadge: {
     ...Typography.label,
@@ -80,9 +77,6 @@ const styles = StyleSheet.create({
     ...Typography.score,
     marginTop: 8,
     color: Colors.text,
-    textShadowColor: "rgba(0, 0, 0, 0.5)",
-    textShadowOffset: { width: 1, height: 1 },
-    textShadowRadius: 4,
   },
   button: {
     marginTop: 32,

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -64,12 +64,14 @@ export default function Game() {
         <Ground scrollX={scrollX} />
       </Animated.View>
 
-      <AnimatedTextInput
-        style={styles.scoreHud}
-        editable={false}
-        animatedProps={scoreProps}
-        pointerEvents="none"
-      />
+      <View style={styles.scoreBadge}>
+        <AnimatedTextInput
+          style={styles.scoreHud}
+          editable={false}
+          animatedProps={scoreProps}
+          pointerEvents="none"
+        />
+      </View>
 
       <Animated.View
         style={[styles.flashOverlay, flashStyle]}
@@ -92,15 +94,21 @@ const styles = StyleSheet.create({
     left: CHARACTER_LEFT,
     bottom: GROUND_HEIGHT,
   },
-  scoreHud: {
+  scoreBadge: {
     position: "absolute",
     top: 60,
-    right: 20,
+    left: 20,
+    borderWidth: 2,
+    borderColor: Colors.text,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    backgroundColor: "rgba(0, 0, 0, 0.2)",
+  },
+  scoreHud: {
     ...Typography.score,
     color: Colors.text,
-    textShadowColor: "rgba(0, 0, 0, 0.5)",
-    textShadowOffset: { width: 1, height: 1 },
-    textShadowRadius: 4,
+    textAlign: "center",
   },
   flashOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/constants/typography.ts
+++ b/constants/typography.ts
@@ -2,6 +2,6 @@
 export const Typography = {
   title: { fontSize: 48, fontWeight: "900", letterSpacing: 4 },
   label: { fontSize: 20, fontWeight: "700", letterSpacing: 3 },
-  score: { fontSize: 36, fontWeight: "700", letterSpacing: 2 },
+  score: { fontSize: 28, fontWeight: "700", letterSpacing: 2 },
   body: { fontSize: 18, letterSpacing: 3 },
 } as const;


### PR DESCRIPTION
## Summary
- Replace text shadow styling with a bordered badge container for the score HUD
- Move score position from right to left side of the screen
- Reduce score font size from 36 to 28
- Remove text shadows from game-over screen score displays

## Test plan
- [x] Verify score badge displays correctly during gameplay (left side, bordered container)
- [x] Verify game-over screen scores render without text shadows
- [x] Check visual consistency across iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)