### PR TITLE
Update React Native version in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Expo/React Native app (super-red) using Expo SDK 54, React 19, React Native 0.81, and TypeScript (strict mode). Package manager is **pnpm**.
+Expo/React Native app (super-red) using Expo SDK 54, React 19, React Native 0.84, and TypeScript (strict mode). Package manager is **pnpm**.
 
 Key experimental features enabled in `app.json`:
 


### PR DESCRIPTION
## Summary
- Update React Native version reference in CLAUDE.md from 0.81 to 0.84 to match the actual `package.json` dependency

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)