### PR TITLE
Add go script for Expo Go mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
+    "go": "expo start --go",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Summary

- `pnpm go` (`expo start --go`) を実行するショートハンドスクリプトを追加

## Test plan

- [x] `pnpm go` でExpo Goモードが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)