### PR TITLE
Migrate implement-issue command to skill format

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,1 +1,0 @@
-Implement GitHub Issue #$ARGUMENTS using the implement-issue sub-agent.

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: implement-issue
+description: Implement a GitHub issue using the implement-issue agent
+disable-model-invocation: true
+argument-hint: <issue-number>
+context: fork
+agent: implement-issue
+---
+
+Implement GitHub Issue #$ARGUMENTS.


### PR DESCRIPTION
## Summary

- Replace `.claude/commands/implement-issue.md` with `.claude/skills/implement-issue/SKILL.md`
- Uses `context: fork` and `agent: implement-issue` frontmatter for subagent delegation
- `/implement-issue <number>` usage remains unchanged

## Test plan

- [x] Run `/implement-issue <number>` and confirm the implement-issue subagent is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)