### PR TITLE
Centralize SCREEN_WIDTH in constants/game.ts

### DIFF
--- a/components/game/background-objects.tsx
+++ b/components/game/background-objects.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import Animated, {
   type SharedValue,
   useAnimatedStyle,
@@ -11,9 +11,9 @@ import {
   BG_OBJECT_SIZE,
   BG_OBJECT_Y_SPACING,
   GROUND_HEIGHT,
+  SCREEN_WIDTH,
 } from "@/constants/game";
 
-const { width: SCREEN_WIDTH } = Dimensions.get("window");
 const TOTAL_WIDTH = SCREEN_WIDTH + BG_OBJECT_SIZE.width;
 
 const OBJECTS = Array.from({ length: BG_OBJECT_COUNT }, (_, i) => ({

--- a/components/game/ground.tsx
+++ b/components/game/ground.tsx
@@ -1,12 +1,15 @@
-import { Dimensions, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import Animated, {
   type SharedValue,
   useAnimatedStyle,
 } from "react-native-reanimated";
 import { Colors } from "@/constants/colors";
-import { GROUND_HEIGHT, GROUND_MARKER_GAP } from "@/constants/game";
+import {
+  GROUND_HEIGHT,
+  GROUND_MARKER_GAP,
+  SCREEN_WIDTH,
+} from "@/constants/game";
 
-const { width: SCREEN_WIDTH } = Dimensions.get("window");
 const MARKER_COUNT = Math.ceil(SCREEN_WIDTH / GROUND_MARKER_GAP) + 1;
 
 function buildMarkers() {

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -1,3 +1,7 @@
+import { Dimensions } from "react-native";
+
+export const SCREEN_WIDTH = Dimensions.get("window").width;
+
 export const CHARACTER_SIZE = 50;
 export const CHARACTER_HEIGHT = 73;
 export const GROUND_HEIGHT = 350;


### PR DESCRIPTION
## Summary
- Add `SCREEN_WIDTH` constant to `constants/game.ts` using `Dimensions.get("window").width`
- Replace local `SCREEN_WIDTH` definitions in `background-objects.tsx` and `ground.tsx` with the shared import
- Remove unused `Dimensions` imports from both component files

Closes #88

## Test plan
- [x] Verify the game renders correctly on iOS/Android
- [x] Confirm background objects and ground scroll as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)