### PR TITLE
Unify Props type definition style to interface

### DIFF
--- a/components/game/character.tsx
+++ b/components/game/character.tsx
@@ -3,9 +3,9 @@ import type { SharedValue } from "react-native-reanimated";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { CHARACTER_HEIGHT, CHARACTER_SIZE } from "@/constants/game";
 
-type CharacterProps = {
+interface CharacterProps {
   y: SharedValue<number>;
-};
+}
 
 export function Character({ y }: CharacterProps) {
   const animatedStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Summary
- Change `type CharacterProps = { ... }` to `interface CharacterProps { ... }` in `components/game/character.tsx`
- Establishes `interface` as the project convention for Props types

Closes #90

## Test plan
- [x] `pnpm expo lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)