### PR TITLE
Add GitHub Actions workflow to create release on v* tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- `v*` パターンのタグをプッシュすると自動でGitHub Releaseを作成するワークフローを追加
- `generate_release_notes: true` により、前回タグからの差分コミットを元にリリースノートを自動生成
- `softprops/action-gh-release@v2` を使用（事実上のデファクトスタンダード）

## Usage

```bash
git tag v1.0.0
git push origin v1.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)