### PR TITLE
Remove scrolling dotted-line markers from Ground

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -73,7 +73,7 @@ export default function Game() {
         <View style={styles.character}>
           <Character y={characterY} />
         </View>
-        <Ground scrollX={scrollX} />
+        <Ground />
       </Animated.View>
 
       <View style={styles.scoreBadge}>

--- a/components/game/ground.tsx
+++ b/components/game/ground.tsx
@@ -1,45 +1,9 @@
 import { StyleSheet, View } from "react-native";
-import Animated, {
-  type SharedValue,
-  useAnimatedStyle,
-} from "react-native-reanimated";
 import { Colors } from "@/constants/colors";
-import {
-  GROUND_HEIGHT,
-  GROUND_MARKER_GAP,
-  SCREEN_WIDTH,
-} from "@/constants/game";
+import { GROUND_HEIGHT } from "@/constants/game";
 
-const MARKER_COUNT = Math.ceil(SCREEN_WIDTH / GROUND_MARKER_GAP) + 1;
-
-function buildMarkers() {
-  const markers = [];
-  for (let i = 0; i < MARKER_COUNT * 2; i++) {
-    markers.push(
-      <View key={i} style={[styles.marker, { left: i * GROUND_MARKER_GAP }]} />,
-    );
-  }
-  return markers;
-}
-
-interface GroundProps {
-  scrollX: SharedValue<number>;
-}
-
-export function Ground({ scrollX }: GroundProps) {
-  const markersStyle = useAnimatedStyle(() => {
-    "worklet";
-    const offset = scrollX.value % (MARKER_COUNT * GROUND_MARKER_GAP);
-    return { transform: [{ translateX: offset }] };
-  });
-
-  return (
-    <View style={styles.ground}>
-      <Animated.View style={[styles.markersContainer, markersStyle]}>
-        {buildMarkers()}
-      </Animated.View>
-    </View>
-  );
+export function Ground() {
+  return <View style={styles.ground} />;
 }
 
 const styles = StyleSheet.create({
@@ -50,20 +14,5 @@ const styles = StyleSheet.create({
     right: 0,
     height: GROUND_HEIGHT,
     backgroundColor: Colors.ground,
-    overflow: "hidden",
-  },
-  markersContainer: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    bottom: 0,
-    flexDirection: "row",
-  },
-  marker: {
-    position: "absolute",
-    top: GROUND_HEIGHT / 2 - 1,
-    width: 12,
-    height: 2,
-    backgroundColor: Colors.groundMarker,
   },
 });

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -3,6 +3,5 @@ export const Colors = {
   title: "#FF2D6F", // hot pink
   text: "#FFFFFF", // white
   ground: "#2A8F86", // dark teal
-  groundMarker: "#4DC9BE", // light teal
   bgObject: "#34A196", // subtle dark teal
 } as const;

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -12,7 +12,6 @@ export const GRAVITY = 0.8;
 
 export const SCROLL_SPEED_MIN = 3;
 export const SCROLL_SPEED_MAX = 5;
-export const GROUND_MARKER_GAP = 40;
 export const BG_OBJECT_COUNT = 4;
 export const BG_OBJECT_SIZE = { width: 20, height: 20 };
 export const BG_OBJECT_BASE_OFFSET = 40;


### PR DESCRIPTION
## Summary

- Removed `buildMarkers()` function and `MARKER_COUNT` constant from `Ground` component
- Removed `GroundProps` interface and `scrollX` prop; component now takes no props
- Replaced `Animated.View` + `useAnimatedStyle` with a plain `<View>`
- Removed unused imports: `GROUND_MARKER_GAP`, `SCREEN_WIDTH`, `useAnimatedStyle`, `SharedValue`
- Removed `markersContainer` and `marker` style entries
- Removed `scrollX` prop from `<Ground />` call site in `app/game.tsx`
- Removed `GROUND_MARKER_GAP` constant from `constants/game.ts`
- Removed `groundMarker` color from `constants/colors.ts`

Closes #114

## Test plan

- [x] Verify ground renders correctly without dotted-line markers
- [x] Verify game runs without TypeScript or lint errors
- [x] Confirm `pnpm expo lint`, `pnpm format:check`, and `pnpm tsc --noEmit` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)