### PR TITLE
Add HUD layout constants to constants/game.ts

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -12,7 +12,16 @@ import { Ground } from "@/components/game/ground";
 import { Items } from "@/components/game/items";
 import { GameButton } from "@/components/ui/game-button";
 import { Colors } from "@/constants/colors";
-import { CHARACTER_LEFT, GROUND_HEIGHT } from "@/constants/game";
+import {
+  CHARACTER_LEFT,
+  GROUND_HEIGHT,
+  HUD_BACKGROUND_OPACITY,
+  HUD_BORDER_RADIUS,
+  HUD_BORDER_WIDTH,
+  HUD_SIDE_PADDING,
+  HUD_TOP_OFFSET,
+  PAUSE_OVERLAY_BACKGROUND_OPACITY,
+} from "@/constants/game";
 import { Typography } from "@/constants/typography";
 import { useGameLoop } from "@/hooks/use-game-loop";
 
@@ -128,16 +137,16 @@ const styles = StyleSheet.create({
   },
   scoreBadge: {
     position: "absolute",
-    top: 60,
-    left: 20,
+    top: HUD_TOP_OFFSET,
+    left: HUD_SIDE_PADDING,
     flexDirection: "row",
     alignItems: "baseline",
-    borderWidth: 2,
+    borderWidth: HUD_BORDER_WIDTH,
     borderColor: Colors.text,
-    borderRadius: 8,
+    borderRadius: HUD_BORDER_RADIUS,
     paddingVertical: 6,
     paddingHorizontal: 14,
-    backgroundColor: "rgba(0, 0, 0, 0.2)",
+    backgroundColor: `rgba(0, 0, 0, ${HUD_BACKGROUND_OPACITY})`,
   },
   scoreHud: {
     ...Typography.score,
@@ -157,16 +166,16 @@ const styles = StyleSheet.create({
   },
   pauseButtonWrapper: {
     position: "absolute",
-    top: 60,
-    right: 20,
+    top: HUD_TOP_OFFSET,
+    right: HUD_SIDE_PADDING,
   },
   pauseButton: {
-    borderWidth: 2,
+    borderWidth: HUD_BORDER_WIDTH,
     borderColor: Colors.text,
-    borderRadius: 8,
+    borderRadius: HUD_BORDER_RADIUS,
     paddingVertical: 6,
     paddingHorizontal: 14,
-    backgroundColor: "rgba(0, 0, 0, 0.2)",
+    backgroundColor: `rgba(0, 0, 0, ${HUD_BACKGROUND_OPACITY})`,
   },
   pauseButtonText: {
     ...Typography.score,
@@ -175,7 +184,7 @@ const styles = StyleSheet.create({
   },
   pauseOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    backgroundColor: `rgba(0, 0, 0, ${PAUSE_OVERLAY_BACKGROUND_OPACITY})`,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -45,3 +45,10 @@ export const CLOUD_MIN_GAP = 100;
 export const CLOUD_MAX_GAP = 400;
 export const CLOUD_PARALLAX_FACTOR = 0.3;
 export const CLOUD_Y_POSITIONS = [600, 700, 800];
+
+export const HUD_TOP_OFFSET = 60;
+export const HUD_SIDE_PADDING = 20;
+export const HUD_BORDER_WIDTH = 2;
+export const HUD_BORDER_RADIUS = 8;
+export const HUD_BACKGROUND_OPACITY = 0.2;
+export const PAUSE_OVERLAY_BACKGROUND_OPACITY = 0.6;


### PR DESCRIPTION
## Summary
- Add named HUD layout constants (`HUD_TOP_OFFSET`, `HUD_SIDE_PADDING`, `HUD_BORDER_WIDTH`, `HUD_BORDER_RADIUS`, `HUD_BACKGROUND_OPACITY`, `PAUSE_OVERLAY_BACKGROUND_OPACITY`) to `constants/game.ts`
- Replace all corresponding magic numbers and rgba color literals in the `app/game.tsx` stylesheet with these constants
- Provides a single place to adjust HUD layout values, consistent with existing patterns in `constants/game.ts`

Closes #121

## Test plan
- [x] Verify the game screen renders identically before and after the change (score badge, pause button, pause overlay)
- [x] Confirm HUD positioning and styling are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)