### PR TITLE
Fix agent-team-implement-issues skill: specify subagent_type general-purpose

### DIFF
--- a/.claude/skills/agent-team-implement-issues/SKILL.md
+++ b/.claude/skills/agent-team-implement-issues/SKILL.md
@@ -27,6 +27,7 @@ Call `TeamCreate` with `team_name: "implement-issues"`.
 
 In a **single message**, spawn one teammate per valid issue using the `Task` tool:
 
+- `subagent_type`: `"general-purpose"`
 - `team_name`: `"implement-issues"`
 - `name`: `"issue-<number>"`
 - `prompt`: `"Read the file at .claude/agents/implement-issue.md and follow its instructions to implement GitHub Issue #<number>. You are a teammate in an agent team — do NOT spawn sub-agents or use the Task tool. Implement everything directly yourself."`


### PR DESCRIPTION
## Summary

- `subagent_type: "general-purpose"` を Task 呼び出しに追加
- 指定がない場合 Claude が `implement-issue` を選択してしまい、その `model: inherit` がteammateコンテキストで失敗していた（詳細は #136）

## Root cause

- Teammateは独立した新規セッションのため `mainLoopModel` が `undefined`
- `model: inherit` はバイナリ内の `yOR` 関数で `mainLoopModel` をそのまま返す設計のため、`undefined` がAPIに渡りエラーになる
- `general-purpose` はすべてのツールを持ち、モデル解決も問題ない

## Test plan

- [x] `/agent-team-implement-issues` スキルでIssueを並行実装し、teammates が正常に起動することを確認

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)