### PR TITLE
Centralize image asset imports in constants/assets.ts

### DIFF
--- a/components/game/bombs.tsx
+++ b/components/game/bombs.tsx
@@ -3,6 +3,7 @@ import Animated, {
   type SharedValue,
   useAnimatedStyle,
 } from "react-native-reanimated";
+import { ASSETS } from "@/constants/assets";
 import {
   BOMB_COUNT,
   BOMB_HEIGHT,
@@ -23,10 +24,7 @@ function Bomb({
   });
 
   return (
-    <Animated.Image
-      source={require("@/assets/images/bomb.png")}
-      style={[styles.bomb, animatedStyle]}
-    />
+    <Animated.Image source={ASSETS.bomb} style={[styles.bomb, animatedStyle]} />
   );
 }
 

--- a/components/game/character.tsx
+++ b/components/game/character.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { ASSETS } from "@/constants/assets";
 import { CHARACTER_HEIGHT, CHARACTER_SIZE } from "@/constants/game";
 
 interface CharacterProps {
@@ -14,7 +15,7 @@ export function Character({ y }: CharacterProps) {
 
   return (
     <Animated.Image
-      source={require("@/assets/images/character.png")}
+      source={ASSETS.character}
       style={[styles.character, animatedStyle]}
     />
   );

--- a/components/game/clouds.tsx
+++ b/components/game/clouds.tsx
@@ -3,6 +3,7 @@ import Animated, {
   type SharedValue,
   useAnimatedStyle,
 } from "react-native-reanimated";
+import { ASSETS } from "@/constants/assets";
 import {
   CLOUD_COUNT,
   CLOUD_MAX_GAP,
@@ -56,7 +57,7 @@ function Cloud({
 
   return (
     <Animated.Image
-      source={require("@/assets/images/cloud.png")}
+      source={ASSETS.cloud}
       style={[styles.cloud, { bottom }, animatedStyle]}
     />
   );

--- a/components/game/items.tsx
+++ b/components/game/items.tsx
@@ -3,12 +3,13 @@ import Animated, {
   type SharedValue,
   useAnimatedStyle,
 } from "react-native-reanimated";
+import { ASSETS } from "@/constants/assets";
 import { GROUND_HEIGHT, ITEM_COUNT, ITEM_SIZE } from "@/constants/game";
 
 const FOOD_IMAGES: ImageSourcePropType[] = [
-  require("@/assets/images/food1.png"),
-  require("@/assets/images/food2.png"),
-  require("@/assets/images/food3.png"),
+  ASSETS.food1,
+  ASSETS.food2,
+  ASSETS.food3,
 ];
 
 function FoodImage({

--- a/constants/assets.ts
+++ b/constants/assets.ts
@@ -1,0 +1,8 @@
+export const ASSETS = {
+  character: require("@/assets/images/character.png"),
+  bomb: require("@/assets/images/bomb.png"),
+  cloud: require("@/assets/images/cloud.png"),
+  food1: require("@/assets/images/food1.png"),
+  food2: require("@/assets/images/food2.png"),
+  food3: require("@/assets/images/food3.png"),
+} as const;


### PR DESCRIPTION
## Summary
- Create `constants/assets.ts` as a single source of truth for all image asset `require()` calls
- Replace inline `require()` calls in `character.tsx`, `bombs.tsx`, `clouds.tsx`, and `items.tsx` with references to the `ASSETS` constant
- Consistent with the existing `constants/` pattern in the project

Closes #124

## Test plan
- [x] Verify all game assets (character, bomb, cloud, food items) render correctly on iOS
- [ ] Verify all game assets render correctly on Android
- [x] Confirm no runtime errors related to asset loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)