### PR TITLE
Use ~ instead of hardcoded /Users/adtak in implement-issue agent

### DIFF
--- a/.claude/agents/implement-issue.md
+++ b/.claude/agents/implement-issue.md
@@ -13,9 +13,9 @@ When invoked, you will receive a GitHub issue number. Follow these steps:
 1. **Read the issue**: Run `gh issue view <number>` to understand the requirements
 2. **Explore the codebase**: Understand relevant existing code before making changes
 3. **Create a feature branch using worktree**:
-   - First pull main: `git -C /Users/adtak/repo/super-red pull origin main`
-   - Create a worktree with a new branch: `git -C /Users/adtak/repo/super-red worktree add ../super-red-<branch-name> -b <branch-name> main`
-   - Work inside the worktree directory (`/Users/adtak/repo/super-red-<branch-name>`)
+   - First pull main: `git -C ~/repo/super-red pull origin main`
+   - Create a worktree with a new branch: `git -C ~/repo/super-red worktree add ../super-red-<branch-name> -b <branch-name> main`
+   - Work inside the worktree directory (`~/repo/super-red-<branch-name>`)
    - Branch names: kebab-case based on issue content (e.g., `add-user-profile`)
    - **Run `pnpm install` immediately after creating the worktree** before any other commands
 4. **Implement**: Follow project conventions from CLAUDE.md:
@@ -31,7 +31,7 @@ When invoked, you will receive a GitHub issue number. Follow these steps:
 6. **Commit**: Small, focused commits with clear messages
 7. **Create a PR**: Push and open a PR to main using `gh pr create`
 8. **Clean up worktree**: After PR is created, remove the worktree:
-   - `git -C /Users/adtak/repo/super-red worktree remove ../super-red-<branch-name>`
+   - `git -C ~/repo/super-red worktree remove ../super-red-<branch-name>`
 
 Keep commits small and focused. Each commit should represent a single logical change.
 Write commit messages, PR titles, and code comments in English.


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/adtak/repo/super-red` paths with `~/repo/super-red` in `.claude/agents/implement-issue.md`
- Tilde expansion works correctly in Bash, so this is portable and avoids hardcoding the username

## Test plan
- [x] Verify the implement-issue agent still functions correctly with the updated paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)