### PR TITLE
Add houses to game background

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -6,6 +6,7 @@ import { Bombs } from "@/components/game/bombs";
 import { Character } from "@/components/game/character";
 import { Clouds } from "@/components/game/clouds";
 import { Ground } from "@/components/game/ground";
+import { Houses } from "@/components/game/houses";
 import { Items } from "@/components/game/items";
 import { PauseOverlay } from "@/components/game/pause-overlay";
 import { ScoreBadge } from "@/components/game/score-badge";
@@ -48,6 +49,7 @@ export default function Game() {
         <Clouds scrollX={scrollX} />
         <Birds scrollX={scrollX} />
         <BackgroundObjects scrollX={scrollX} />
+        <Houses scrollX={scrollX} />
         <Bombs positions={bombPositions} />
         <Items
           positions={itemPositions}

--- a/components/game/houses.tsx
+++ b/components/game/houses.tsx
@@ -1,0 +1,82 @@
+import { StyleSheet, View } from "react-native";
+import Animated, {
+  type SharedValue,
+  useAnimatedStyle,
+} from "react-native-reanimated";
+import { ASSETS } from "@/constants/assets";
+import {
+  GROUND_HEIGHT,
+  HOUSE_COUNT,
+  HOUSE_MAX_GAP,
+  HOUSE_MIN_GAP,
+  HOUSE_PARALLAX_FACTOR,
+  HOUSE_SIZE,
+  SCREEN_WIDTH,
+} from "@/constants/game";
+import { randomInRange } from "@/utils/random";
+
+const { HOUSES, TOTAL_WIDTH } = (() => {
+  const houses = [];
+  let currentX = 0;
+  for (let i = 0; i < HOUSE_COUNT; i++) {
+    houses.push({
+      id: i,
+      xOffset: currentX,
+    });
+    const gap = randomInRange(HOUSE_MIN_GAP, HOUSE_MAX_GAP);
+    currentX += HOUSE_SIZE.width + gap;
+  }
+  const finalGap = randomInRange(HOUSE_MIN_GAP, HOUSE_MAX_GAP);
+  return { HOUSES: houses, TOTAL_WIDTH: currentX + finalGap };
+})();
+
+interface HousesProps {
+  scrollX: SharedValue<number>;
+}
+
+function House({
+  scrollX,
+  xOffset,
+}: {
+  scrollX: SharedValue<number>;
+  xOffset: number;
+}) {
+  const animatedStyle = useAnimatedStyle(() => {
+    "worklet";
+    let x =
+      ((scrollX.value * HOUSE_PARALLAX_FACTOR + xOffset) % TOTAL_WIDTH) +
+      SCREEN_WIDTH;
+    if (x > SCREEN_WIDTH) {
+      x -= TOTAL_WIDTH;
+    }
+    return { transform: [{ translateX: x }] };
+  });
+
+  return (
+    <Animated.Image
+      source={ASSETS.house}
+      style={[styles.house, { bottom: GROUND_HEIGHT }, animatedStyle]}
+    />
+  );
+}
+
+export function Houses({ scrollX }: HousesProps) {
+  return (
+    <View style={styles.container}>
+      {HOUSES.map((house) => (
+        <House key={house.id} scrollX={scrollX} xOffset={house.xOffset} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  house: {
+    position: "absolute",
+    width: HOUSE_SIZE.width,
+    height: HOUSE_SIZE.height,
+  },
+});

--- a/constants/assets.ts
+++ b/constants/assets.ts
@@ -3,6 +3,7 @@ export const ASSETS = {
   bomb: require("@/assets/images/bomb.png"),
   bird: require("@/assets/images/bird.png"),
   cloud: require("@/assets/images/cloud.png"),
+  house: require("@/assets/images/house.png"),
   food1: require("@/assets/images/food1.png"),
   food2: require("@/assets/images/food2.png"),
   food3: require("@/assets/images/food3.png"),

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -53,6 +53,12 @@ export const BIRD_MAX_GAP = 600;
 export const BIRD_PARALLAX_FACTOR = 0.5;
 export const BIRD_Y_POSITIONS = [500, 650];
 
+export const HOUSE_COUNT = 3;
+export const HOUSE_SIZE = { width: 80, height: 100 };
+export const HOUSE_MIN_GAP = 200;
+export const HOUSE_MAX_GAP = 500;
+export const HOUSE_PARALLAX_FACTOR = 0.7;
+
 export const HUD_TOP_OFFSET = 60;
 export const HUD_SIDE_PADDING = 20;
 export const HUD_BORDER_WIDTH = 2;


### PR DESCRIPTION
## Summary

- Add house-related constants (`HOUSE_COUNT`, `HOUSE_SIZE`, `HOUSE_MIN_GAP`, `HOUSE_MAX_GAP`, `HOUSE_PARALLAX_FACTOR`) to `constants/game.ts`
- Register `house` asset in `constants/assets.ts`
- Create `components/game/houses.tsx` following the same scrolling parallax pattern as `clouds.tsx` and `birds.tsx`
- Integrate `<Houses scrollX={scrollX} />` into `app/game.tsx` between `<BackgroundObjects />` and `<Bombs />`

Houses sit at `GROUND_HEIGHT` and use a parallax factor of `0.7`, making them appear closer to the viewer than clouds (`0.3`) or birds (`0.5`), adding depth to the background scene.

Closes #67

## Test plan

- [x] Houses appear along the ground line in the game screen
- [x] Houses scroll horizontally and loop seamlessly
- [x] Houses move faster than clouds/birds (higher parallax factor = closer)
- [x] Houses render behind bombs and game objects
- [x] No TypeScript errors (`pnpm tsc --noEmit`)
- [x] Linting passes (`pnpm expo lint`, `pnpm format:check`)

Generated with [Claude Code](https://claude.com/claude-code)