### PR TITLE
Avoid spread-based array copies in game loop worklets

### DIFF
--- a/hooks/use-bombs.ts
+++ b/hooks/use-bombs.ts
@@ -28,11 +28,17 @@ export function useBombs() {
     characterY: SharedValue<number>,
   ): boolean => {
     "worklet";
-    const positions = bombPositions.value.slice();
+    // A new array must be assigned to SharedValue to trigger change detection,
+    // so a copy is unavoidable. Use spread instead of slice for clarity.
+    const positions = [...bombPositions.value];
     for (let i = 0; i < positions.length; i++) {
       positions[i] -= scrollSpeed.value;
       if (positions[i] < -BOMB_SIZE) {
-        const max = Math.max(...positions);
+        // Avoid Math.max(...positions) spread to reduce GC pressure.
+        let max = positions[0];
+        for (let j = 1; j < positions.length; j++) {
+          if (positions[j] > max) max = positions[j];
+        }
         const gap = randomInRange(BOMB_MIN_GAP, BOMB_MAX_GAP);
         positions[i] = max + gap;
       }

--- a/hooks/use-items.ts
+++ b/hooks/use-items.ts
@@ -41,15 +41,21 @@ export function useItems() {
     characterY: SharedValue<number>,
   ) => {
     "worklet";
-    const itemPos = itemPositions.value.slice();
-    const itemY = itemYOffsets.value.slice();
-    const active = itemActive.value.slice();
-    const imageIndices = itemImageIndices.value.slice();
+    // A new array must be assigned to SharedValue to trigger change detection,
+    // so copies are unavoidable. Use spread instead of slice for clarity.
+    const itemPos = [...itemPositions.value];
+    const itemY = [...itemYOffsets.value];
+    const active = [...itemActive.value];
+    const imageIndices = [...itemImageIndices.value];
 
     for (let i = 0; i < itemPos.length; i++) {
       itemPos[i] -= scrollSpeed.value;
       if (itemPos[i] < -ITEM_SIZE) {
-        const max = Math.max(...itemPos);
+        // Avoid Math.max(...itemPos) spread to reduce GC pressure.
+        let max = itemPos[0];
+        for (let j = 1; j < itemPos.length; j++) {
+          if (itemPos[j] > max) max = itemPos[j];
+        }
         const gap = randomInRange(ITEM_MIN_GAP, ITEM_MAX_GAP);
         itemPos[i] = max + gap;
         itemY[i] = randomInRange(ITEM_Y_MAX, ITEM_Y_MIN);


### PR DESCRIPTION
## Summary

- Replace `Math.max(...arr)` with an explicit for-loop in `use-bombs.ts` and `use-items.ts` to avoid creating temporary argument lists on every frame (60 fps)
- Replace `.slice()` with spread syntax (`[...arr]`) for consistency and clarity
- Add comments explaining why array copies are unavoidable with Reanimated SharedValue

Note: Array copies themselves cannot be eliminated because Reanimateds SharedValue requires a new array reference to detect changes. However, removing the additional spread in Math.max(...arr) reduces per-frame GC allocations.

Closes #132

## Test plan

- [ ] Verify the game runs correctly with bombs falling and items appearing
- [ ] Confirm bomb collision detection still triggers game over
- [ ] Confirm item collection still increments score

Generated with Claude Code